### PR TITLE
Fixed compatibility issues with last version of Landing Pages plugin

### DIFF
--- a/blog/body.html.erb
+++ b/blog/body.html.erb
@@ -1,4 +1,4 @@
-<% if current_user %><% set_category_user('blog') %><% end %>
+<% set_category_user(@page.category_id) %>
 
 <% content_for :head do %>
   <meta name="description" content="Pavilion's example blog for our Blog Landing Pages">
@@ -6,12 +6,6 @@
   <meta property="og:description" content="Pavilion's example blog for our Blog Landing Pages" />
   <meta property="og:image" content="https://pavilion-assets.nyc3.digitaloceanspaces.com/landing/logo-blog.png" />
 <% end %>
-
-<%= render partial: "header", locals: {
-  logo_url: "https://pavilion-assets.nyc3.digitaloceanspaces.com/landing/logo-blog.png",
-  title: "Try Blog",
-  root: "/blog"
-} %>
 
 <div class="blog-title">
   <h1>Example Blog</h1>
@@ -23,7 +17,7 @@
       render_list: true
     },
     list_opts: {
-      category: 'blog',
+      category: @page.category_id,
       no_definitions: true,
       per_page: 10,
       page: params[:page]
@@ -48,15 +42,13 @@
   <% end %>
 </div>
 
-<% if current_user && @category_user.present? %>
+<% if @category_user.present? %>
   <%= render partial: 'modal', locals: {
     title: "Subscribe",
     class: "subscribe",
     content: render(partial: "subscription_form", locals: {
       category_id: @category_user.category.id,
-      subscribed: (@category_user &&
-        @category_user.notification_level >= CategoryUser.notification_levels[:watching_first_post]
-      )
+      subscribed: @category_user.notification_level >= CategoryUser.notification_levels[:watching_first_post]
     })
   } %>
 <% end %>

--- a/blog_post/body.html.erb
+++ b/blog_post/body.html.erb
@@ -1,4 +1,5 @@
-<% if current_user %><% set_category_user('blog') %><% end %>
+<% set_parent_page(@page.parent_id) %>
+<% set_category_user(@parent_page.category_id) %>
 <% get_topic_view(params[:param], opts: { include_suggested: false, include_related: false, post_number: 1 }, instance_var: "topic_view", set_page_title: true) %>
 
 <% content_for :head do %>
@@ -7,12 +8,6 @@
   <meta property="og:description" content="<%= @topic_view.posts.first.excerpt_for_topic %>" />
   <meta property="og:image" content="<%= @topic_view.topic.image_url %>" />
 <% end %>
-
-<%= render partial: "header", locals: {
-  logo_url: "https://pavilion-assets.nyc3.digitaloceanspaces.com/landing/logo-blog.png",
-  title: "Try Blog",
-  root: "/blog"
-} %>
 
 <% if @topic_view.present? %>
   <div class="title-container" <% unless mobile_view? %> style="background-image: url(<%= @topic_view.topic.image_url %>) <% end %>">
@@ -30,7 +25,7 @@
   </div>
 <% end %>
 
-<a href="/blog" class="btn btn-fixed btn-blog" title="Posts">
+<a href="/<%= @parent_page.path %>" class="btn btn-fixed btn-blog" title="Posts">
   <div class="fixed-icon"><%= SvgSprite.raw_svg('stream') %></div>
   <% unless mobile_view? %>
     <div class="fixed-label">Posts</div>
@@ -80,15 +75,13 @@
   <% end %>
 </div>
 
-<% if current_user && @category_user.present? %>
+<% if @category_user.present? %>
   <%= render partial: 'modal', locals: {
     title: "Subscribe",
     class: "subscribe",
     content: render(partial: "subscription_form", locals: {
       category_id: @category_user.category.id,
-      subscribed: (@category_user &&
-        @category_user.notification_level >= CategoryUser.notification_levels[:watching_first_post]
-      )
+      subscribed: @category_user.notification_level >= CategoryUser.notification_levels[:watching_first_post]
     })
   } %>
 <% end %>

--- a/pages.json
+++ b/pages.json
@@ -1,0 +1,7 @@
+{
+  "header": {
+    "logo_url": "https://pavilion-assets.nyc3.digitaloceanspaces.com/landing/logo-blog.png",
+    "title": "Try Blog",
+    "root": "/blog"
+  }
+}


### PR DESCRIPTION
This adds the minimal updates required for the Blog Landing pages to be compatible with the latest version of the Landing Pages plugin:
- Switches the hardcoded `'blog'` category to the actual category set in the parent page configuration.
- Moves the header configuration to the "Globals" section.
- Imports the parent page settings to be used in the child page.