### PR TITLE
Updated subscription button to show for logged users only

### DIFF
--- a/blog/body.html.erb
+++ b/blog/body.html.erb
@@ -31,20 +31,16 @@
   )%>
 </div>
 
-<div class="btn btn-fixed btn-subscribe <% if current_user %>user<% else %>guest<% end %>" title="Subscribe">
-  <% if current_user %>
-    <img class="fixed-avatar" src="<%= current_user.avatar_template_url.gsub("{size}", "65") %>">
-  <% else %>
-    <div class="fixed-icon"><%= SvgSprite.raw_svg('user-circle') %></div>
-  <% end %>
-  <% unless mobile_view? %>
-    <div class="fixed-label">Subscribe</div>
-  <% end %>
-</div>
-
 <% if @category_user.present? %>
+  <div class="btn btn-fixed btn-subscribe user" title="Subscription">
+    <img class="fixed-avatar" src="<%= current_user.avatar_template_url.gsub("{size}", "65") %>">
+    <% unless mobile_view? %>
+      <div class="fixed-label">Subscription</div>
+    <% end %>
+  </div>
+
   <%= render partial: 'modal', locals: {
-    title: "Subscribe",
+    title: "Update your subscription",
     class: "subscribe",
     content: render(partial: "subscription_form", locals: {
       category_id: @category_user.category.id,

--- a/blog_post/body.html.erb
+++ b/blog_post/body.html.erb
@@ -10,9 +10,9 @@
 <% end %>
 
 <% if @topic_view.present? %>
-  <div class="title-container" <% unless mobile_view? %> style="background-image: url(<%= @topic_view.topic.image_url %>) <% end %>">
+  <div class="title-container" <% unless mobile_view? %>style="background-image: url(<%= @topic_view.topic.image_url %>);"<% end %>>
     <div class="contents canvas">
-      <h1 title="<%= @topic_view.title %>" class="title"><%= @topic_view.title %></h1>
+      <h1 class="title"><%= emoji_codes_to_img(@topic_view.title) %></h1>
       <%= render partial: 'topic_byline', locals: {
         topic: @topic_view.topic,
         include_link: true,
@@ -64,20 +64,16 @@
   </article>
 <% end %>
 
-<div class="btn btn-fixed btn-subscribe <% if current_user %>user<% else %>guest<% end %>" title="Subscribe">
-  <% if current_user %>
-    <img class="fixed-avatar" src="<%= current_user.avatar_template_url.gsub("{size}", "65") %>">
-  <% else %>
-    <div class="fixed-icon"><%= SvgSprite.raw_svg('user-circle') %></div>
-  <% end %>
-  <% unless mobile_view? %>
-    <div class="fixed-label">Subscribe</div>
-  <% end %>
-</div>
-
 <% if @category_user.present? %>
+  <div class="btn btn-fixed btn-subscribe user" title="Subscription">
+    <img class="fixed-avatar" src="<%= current_user.avatar_template_url.gsub("{size}", "65") %>">
+    <% unless mobile_view? %>
+      <div class="fixed-label">Subscription</div>
+    <% end %>
+  </div>
+
   <%= render partial: 'modal', locals: {
-    title: "Subscribe",
+    title: "Update your subscription",
     class: "subscribe",
     content: render(partial: "subscription_form", locals: {
       category_id: @category_user.category.id,


### PR DESCRIPTION
This removes the subscription button when the user is not logged in to simplify navigation. It also renders emojis in the title of the blog post view now.

Relates to paviliondev/blog-landing-theme#4 and paviliondev/discourse-landing-pages#29.